### PR TITLE
update response for success ProviderAccount delete

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1060,8 +1060,8 @@ paths:
       description: "The delete provider account service is used to delete a provider account <br>from the Yodlee system. This service also deletes the accounts that are created in the <br>Yodlee system for that provider account. This service does not return a response. <br>The HTTP response code is 204 (Success with no content).<br>"
       operationId: "deleteProviderAccount"
       responses:
-        200:
-          description: "OK"
+        204:
+          description: "The Provider Account was successfully deleted"
         400:
           schema:
             $ref: "#/definitions/YodleeError"


### PR DESCRIPTION
Using the Yodlee API, I have found that when it was successfully deleting a provider account it was returning a 204 response when the client generated from the swagger was expecting a 200 response.